### PR TITLE
Identity: add 'enabled' field on Endpoint

### DIFF
--- a/openstack/identity/v3/endpoints/results.go
+++ b/openstack/identity/v3/endpoints/results.go
@@ -57,6 +57,9 @@ type Endpoint struct {
 
 	// URL is the url of the Endpoint.
 	URL string `json:"url"`
+
+	// Enabled is whether or not the endpoint is enabled.
+	Enabled bool `json:"enabled"`
 }
 
 // EndpointPage is a single page of Endpoint results.

--- a/openstack/identity/v3/endpoints/testing/requests_test.go
+++ b/openstack/identity/v3/endpoints/testing/requests_test.go
@@ -37,7 +37,8 @@ func TestCreateSuccessful(t *testing.T) {
         "endpoint": {
           "id": "12",
           "interface": "public",
-          "links": {
+		  "enabled": true,
+		  "links": {
             "self": "https://localhost:5000/v3/endpoints/12"
           },
           "name": "the-endiest-of-points",
@@ -61,6 +62,7 @@ func TestCreateSuccessful(t *testing.T) {
 	expected := &endpoints.Endpoint{
 		ID:           "12",
 		Availability: gophercloud.AvailabilityPublic,
+		Enabled:      true,
 		Name:         "the-endiest-of-points",
 		Region:       "underground",
 		ServiceID:    "asdfasdfasdfasdf",
@@ -85,6 +87,7 @@ func TestListEndpoints(t *testing.T) {
 					{
 						"id": "12",
 						"interface": "public",
+						"enabled": true,
 						"links": {
 							"self": "https://localhost:5000/v3/endpoints/12"
 						},
@@ -96,6 +99,7 @@ func TestListEndpoints(t *testing.T) {
 					{
 						"id": "13",
 						"interface": "internal",
+						"enabled": false,
 						"links": {
 							"self": "https://localhost:5000/v3/endpoints/13"
 						},
@@ -126,6 +130,7 @@ func TestListEndpoints(t *testing.T) {
 			{
 				ID:           "12",
 				Availability: gophercloud.AvailabilityPublic,
+				Enabled:      true,
 				Name:         "the-endiest-of-points",
 				Region:       "underground",
 				ServiceID:    "asdfasdfasdfasdf",
@@ -134,6 +139,7 @@ func TestListEndpoints(t *testing.T) {
 			{
 				ID:           "13",
 				Availability: gophercloud.AvailabilityInternal,
+				Enabled:      false,
 				Name:         "shhhh",
 				Region:       "underground",
 				ServiceID:    "asdfasdfasdfasdf",
@@ -167,6 +173,7 @@ func TestUpdateEndpoint(t *testing.T) {
 			"endpoint": {
 				"id": "12",
 				"interface": "public",
+				"enabled": true,
 				"links": {
 					"self": "https://localhost:5000/v3/endpoints/12"
 				},
@@ -190,6 +197,7 @@ func TestUpdateEndpoint(t *testing.T) {
 	expected := &endpoints.Endpoint{
 		ID:           "12",
 		Availability: gophercloud.AvailabilityPublic,
+		Enabled:      true,
 		Name:         "renamed",
 		Region:       "somewhere-else",
 		ServiceID:    "asdfasdfasdfasdf",


### PR DESCRIPTION
Merge feature add 'enabled' field on Endpoint to v0.12.x branch
