### PR TITLE
update live migrate api with microversion 2.25 #2197

### DIFF
--- a/openstack/compute/v2/extensions/migrate/microversions.go
+++ b/openstack/compute/v2/extensions/migrate/microversions.go
@@ -1,0 +1,25 @@
+package migrate
+
+import "github.com/gophercloud/gophercloud"
+
+// LiveMigrateOpts specifies parameters of live migrate action.
+type LiveMigrate225Opts struct {
+	// The host to which to migrate the server.
+	// If this parameter is None, the scheduler chooses a host.
+	Host *string `json:"host"`
+
+	// Set to True to migrate local disks by using block migration.
+	// If the source or destination host uses shared storage and you set
+	// this value to True, the live migration fails.
+	BlockMigration string `json:"block_migration"`
+
+	// Set to True to enable over commit when the destination host is checked
+	// for available disk space. Set to False to disable over commit. This setting
+	// affects only the libvirt virt driver.
+	DiskOverCommit *bool `json:"disk_over_commit,omitempty"`
+}
+
+// ToLiveMigrateMap constructs a request body from LiveMigrateOpts.
+func (opts LiveMigrate225Opts) ToLiveMigrateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-migrateLive")
+}

--- a/openstack/compute/v2/extensions/migrate/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/migrate/testing/fixtures.go
@@ -31,3 +31,18 @@ func mockLiveMigrateResponse(t *testing.T, id string) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+func mockLiveMigrate225Response(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"os-migrateLive": {
+				"host": "01c0cadef72d47e28a672a76060d492c",
+				"block_migration": "auto",
+				"disk_over_commit": true
+			}
+		}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/migrate/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/migrate/testing/requests_test.go
@@ -39,3 +39,22 @@ func TestLiveMigrate(t *testing.T) {
 	err := migrate.LiveMigrate(client.ServiceClient(), serverID, migrationOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestLiveMigrate225(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockLiveMigrate225Response(t, serverID)
+
+	host := "01c0cadef72d47e28a672a76060d492c"
+	diskOverCommit := true
+
+	migrationOpts := migrate.LiveMigrate225Opts{
+		Host:           &host,
+		BlockMigration: "auto",
+		DiskOverCommit: &diskOverCommit,
+	}
+
+	err := migrate.LiveMigrate(client.ServiceClient(), serverID, migrationOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+}


### PR DESCRIPTION
For #2197

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

https://docs.openstack.org/api-ref/compute/?expanded=live-migrate-server-os-migratelive-action-detail#live-migrate-server-os-migratelive-action
