### PR TITLE
add network_type and segmentation_id to network creation options

### DIFF
--- a/openstack/networking/v2/networks/requests.go
+++ b/openstack/networking/v2/networks/requests.go
@@ -80,6 +80,8 @@ type CreateOpts struct {
 	TenantID              string   `json:"tenant_id,omitempty"`
 	ProjectID             string   `json:"project_id,omitempty"`
 	AvailabilityZoneHints []string `json:"availability_zone_hints,omitempty"`
+	NetworkType           string   `json:"provider:network_type,omitempty"`
+	SegmentationID        int      `json:"provider:segmentation_id,omitempty"`
 }
 
 // ToNetworkCreateMap builds a request body from CreateOpts.


### PR DESCRIPTION
Add options to specify a network_type and a segmentation_id when creating a network.

From https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-network-detail#networks :
* provider:physical_network (Optional)
* provider:segmentation_id (Optional)