### PR TITLE
Add OperatingStatus to loadbalancer listener

### DIFF
--- a/openstack/loadbalancer/v2/listeners/results.go
+++ b/openstack/loadbalancer/v2/listeners/results.go
@@ -66,6 +66,9 @@ type Listener struct {
 	// This value is ACTIVE, PENDING_* or ERROR.
 	ProvisioningStatus string `json:"provisioning_status"`
 
+	// The operating status of the listener
+	OperatingStatus string `json:"operating_status"`
+
 	// Frontend client inactivity timeout in milliseconds
 	TimeoutClientData int `json:"timeout_client_data"`
 


### PR DESCRIPTION
Add an OperatingStatus in loadbalancer.Lister as Octavia loadbalancer listeners have an operating_status:

https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=list-l7-policies-detail,show-listener-details-detail#show-listener-details
https://github.com/openstack/octavia/blob/7557c8f1783a3d66a69d4d45280a0cc993172221/octavia/api/v2/types/listener.py#L39
