### PR TITLE
Fix BareMetalV1 version

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -363,7 +363,11 @@ func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointO
 // NewBareMetalV1 creates a ServiceClient that may be used with the v1
 // bare metal package.
 func NewBareMetalV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "baremetal")
+	sc, err := initClientOpts(client, eo, "baremetal")
+	if !strings.HasSuffix(sc.Endpoint, "v1/") {
+		sc.ResourceBase = sc.Endpoint + "v1/"
+	}
+	return sc, err
 }
 
 // NewBareMetalIntrospectionV1 creates a ServiceClient that may be used with the v1


### PR DESCRIPTION
Add "v1/" to baremetal service endpoint if needed in "NewBareMetalV1" function.